### PR TITLE
Align partitions

### DIFF
--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -3,7 +3,7 @@
 #
 #  This file is part of os-installer
 #
-#  Copyright 2013-2016 Ikey Doherty <ikey@solus-project.com>
+#  Copyright 2013-2019 Solus <copyright@getsol.us>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/os_installer2/diskops.py
+++ b/os_installer2/diskops.py
@@ -3,7 +3,7 @@
 #
 #  This file is part of os-installer
 #
-#  Copyright 2013-2019 Solus <copyright@getsol.us>
+#  Copyright 2013-2016 Ikey Doherty <ikey@solus-project.com>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -119,6 +119,11 @@ class DiskOpCreatePartition(BaseDiskOp):
     def describe(self):
         return "I should be described by my children. ._."
 
+    def calc_length(self, offset, length, size):
+        """ See if length can be extended in alignment """
+        mod = (offset + length) % size
+        return length + size - mod
+
     def apply(self, disk, simulate):
         """ Create a partition with the given type... """
         try:
@@ -126,8 +131,12 @@ class DiskOpCreatePartition(BaseDiskOp):
                 raise RuntimeError("Cannot create partition on empty disk!")
             length = parted.sizeToSectors(
                 self.size, 'B', disk.device.sectorSize)
+            block_length = parted.sizeToSectors(1, 'MiB', disk.device.sectorSize)
             geom = parted.Geometry(
                 device=self.device, start=self.part_offset, length=length)
+
+            # extend the length to align.  Not necessary but doesnt waste a couple mbs
+            geom.length = self.calc_length(self.part_offset, length, block_length)
 
             # Don't run off the end of the disk ...
             geom_cmp = self.get_all_remaining_geom(

--- a/os_installer2/pages/progress.py
+++ b/os_installer2/pages/progress.py
@@ -3,7 +3,7 @@
 #
 #  This file is part of os-installer
 #
-#  Copyright 2013-2016 Ikey Doherty <ikey@solus-project.com>
+#  Copyright 2013-2019 Solus <copyright@getsol.us>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/os_installer2/pages/progress.py
+++ b/os_installer2/pages/progress.py
@@ -554,7 +554,7 @@ class InstallerProgressPage(BasePage):
                 part_offset = self.round_up_next_block(op.new_part_off, part_step)
             elif isinstance(op, DiskOpCreatePartition):
                 # Push forward the offset
-                part_offset = self.round_up_next_block(op.part_end,part_step)
+                part_offset = self.round_up_next_block(op.part_end, part_step)
 
         if simulate:
             return True

--- a/os_installer2/pages/progress.py
+++ b/os_installer2/pages/progress.py
@@ -3,7 +3,7 @@
 #
 #  This file is part of os-installer
 #
-#  Copyright 2013-2019 Solus <copyright@getsol.us>
+#  Copyright 2013-2016 Ikey Doherty <ikey@solus-project.com>
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -504,6 +504,11 @@ class InstallerProgressPage(BasePage):
             return False
         return True
 
+    def round_up_next_block(self, num, size):
+        """ Given an end sector and blocksize, round to the block """
+        mod = num % size
+        return num + size - mod
+
     def apply_disk_strategy(self, simulate):
         """ Attempt to apply the given disk strategy """
         strategy = self.info.strategy
@@ -524,12 +529,11 @@ class InstallerProgressPage(BasePage):
             disk = disk.duplicate()
 
         part_offset = 0
-        part_step = parted.sizeToSectors(16, 'kB', strategy.device.sectorSize)
+        part_step = parted.sizeToSectors(1, 'MiB', strategy.device.sectorSize)
         if disk:
             # Start at the very beginning of the disk, we don't
             # support free-space installation
-            part_offset = disk.getFirstPartition().geometry.end + part_step
-
+            part_offset = self.round_up_next_block(disk.getFirstPartition().geometry.end, part_step)
         for op in ops:
             self.set_display_string(op.describe())
             op.set_part_offset(part_offset)
@@ -545,12 +549,12 @@ class InstallerProgressPage(BasePage):
                 if not strategy.disk:
                     strategy.disk = disk
                 # Now set the part offset
-                part_offset = disk.getFirstPartition().geometry.end + part_step
+                part_offset = self.round_up_next_block(disk.getFirstPartition().geometry.end, part_step)
             elif isinstance(op, DiskOpResizeOS):
-                part_offset = op.new_part_off + part_step
+                part_offset = self.round_up_next_block(op.new_part_off, part_step)
             elif isinstance(op, DiskOpCreatePartition):
                 # Push forward the offset
-                part_offset = op.part_end + part_step
+                part_offset = self.round_up_next_block(op.part_end,part_step)
 
         if simulate:
             return True


### PR DESCRIPTION
This is an attempt to properly align partitions when creating them. The current incarnation makes no such attempt and gives misaligned partitions. This does cause worse performance, and can cause shortened disk life.
I am not an expert in this distro, nor have I read all of the code. It's been tested (by me) for a new installation with and without LUKS. I do not know if other schemes exist, such as creating partitions alongside existing ones, if so, that should likely be tested.
It's completely fine to not accept this PR as is and tune it yourself. Just offering what worked for me.
I copied these files from the live installer to work with rather than this repo(which explains the copyright commit), so please watchout for other changes that may have existed.