### PR TITLE
pep8 has been renamed to pycodestyle.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pep8 os-installer-gtk  os_installer2/*.py os_installer2/pages/*.py || exit 1
+pycodestyle os-installer-gtk  os_installer2/*.py os_installer2/pages/*.py || exit 1
 flake8 os-installer-gtk  os_installer2/*.py os_installer2/pages/*.py || exit 1
 
 # check use of %s


### PR DESCRIPTION
"Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead."