### PR TITLE
Remove sidebar styling so it follows GTK theme

### DIFF
--- a/os_installer2/data/styling.css
+++ b/os_installer2/data/styling.css
@@ -7,15 +7,3 @@ scrolledwindow {
     background-image: none;
     background-color: transparent;
 }
-
-.header-box {
-    background-color: #222D32;
-    box-shadow: 0 2px 3px 1px alpha(black, 0.47);
-    color: white;
-}
-
-.arc-theme .header-box {
-    background-color: #2F343F;
-    box-shadow: none;
-    color: white;
-}

--- a/os_installer2/mainwindow.py
+++ b/os_installer2/mainwindow.py
@@ -227,9 +227,6 @@ class MainWindow(Gtk.ApplicationWindow):
         self.info.owner = self
 
         self.get_style_context().add_class("installer-window")
-        gtktheme = settings.get_property("gtk-theme-name").lower()
-        if gtktheme.startswith("arc"):
-            self.get_style_context().add_class("arc-theme")
 
         # Hook up actions
         self.prev_button.connect("clicked", lambda x: self.prev_page())


### PR DESCRIPTION
Currently, the sidebar is styled in a way that makes it look bad on current GTK themes on Budgie Desktop (and maybe MATE?) at best, and unreadable at worst. This removes that styling so that the sidebar follows the set GTK theme.