### PR TITLE
Fix timezonemap errors involving non-ASCII "Türkiye"

### DIFF
--- a/os_installer2/tz.py
+++ b/os_installer2/tz.py
@@ -130,9 +130,9 @@ class Iso3166(object):
                  entry.hasAttribute('name'))):
             alpha_2_code = entry.getAttribute('alpha_2_code')
             if entry.hasAttribute('common_name'):
-                name = entry.getAttribute('common_name')
+                name = entry.getAttribute('common_name').encode('utf-8')
             else:
-                name = entry.getAttribute('name')
+                name = entry.getAttribute('name').encode('utf-8')
             self.names[alpha_2_code] = name
 
 


### PR DESCRIPTION
This fixes the following error on the timezone map when selecting Türkiye

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/os_installer2/pages/timezone.py", line 90, in changed
    nice_loc.human_country)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 1: ordinal not in range(128)
```

